### PR TITLE
Implement minimal PHP CRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# pomstud
+# Simple PHP CRM
+
+This repository contains a minimal CRM application written in PHP using SQLite. It allows listing, adding, editing and deleting customers.
+
+## Requirements
+
+* PHP 7.4 or later
+* The `pdo_sqlite` extension enabled
+
+## Usage
+
+1. Run a PHP built-in server from the `src` directory:
+   ```bash
+   php -S localhost:8000 -t src
+   ```
+2. Open your browser at [http://localhost:8000](http://localhost:8000) to use the CRM.
+
+The SQLite database file will be created automatically in `data/crm.sqlite` on first run.

--- a/src/config.php
+++ b/src/config.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'db_path' => __DIR__ . '/../data/crm.sqlite',
+];

--- a/src/db.php
+++ b/src/db.php
@@ -1,0 +1,21 @@
+<?php
+function get_db() {
+    static $db;
+    if (!$db) {
+        $config = include __DIR__ . '/config.php';
+        $db = new PDO('sqlite:' . $config['db_path']);
+        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    }
+    return $db;
+}
+
+function migrate() {
+    $db = get_db();
+    $db->exec("CREATE TABLE IF NOT EXISTS customers (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        email TEXT,
+        phone TEXT,
+        created_at TEXT NOT NULL
+    )");
+}

--- a/src/index.php
+++ b/src/index.php
@@ -1,0 +1,55 @@
+<?php
+require __DIR__ . '/db.php';
+
+migrate();
+
+$action = $_GET['action'] ?? 'list';
+
+switch ($action) {
+    case 'create':
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $db = get_db();
+            $stmt = $db->prepare('INSERT INTO customers (name, email, phone, created_at) VALUES (?, ?, ?, ?)');
+            $stmt->execute([
+                $_POST['name'],
+                $_POST['email'],
+                $_POST['phone'],
+                date('c')
+            ]);
+            header('Location: index.php');
+            exit;
+        }
+        $template = 'customer_form.php';
+        $customer = ['name' => '', 'email' => '', 'phone' => ''];
+        break;
+    case 'edit':
+        $db = get_db();
+        $id = (int)$_GET['id'];
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $stmt = $db->prepare('UPDATE customers SET name=?, email=?, phone=? WHERE id=?');
+            $stmt->execute([
+                $_POST['name'],
+                $_POST['email'],
+                $_POST['phone'],
+                $id
+            ]);
+            header('Location: index.php');
+            exit;
+        }
+        $stmt = $db->prepare('SELECT * FROM customers WHERE id=?');
+        $stmt->execute([$id]);
+        $customer = $stmt->fetch(PDO::FETCH_ASSOC);
+        $template = 'customer_form.php';
+        break;
+    case 'delete':
+        $db = get_db();
+        $id = (int)$_GET['id'];
+        $db->prepare('DELETE FROM customers WHERE id=?')->execute([$id]);
+        header('Location: index.php');
+        exit;
+    default:
+        $db = get_db();
+        $customers = $db->query('SELECT * FROM customers ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+        $template = 'customers.php';
+}
+

--- a/src/templates/customer_form.php
+++ b/src/templates/customer_form.php
@@ -1,0 +1,17 @@
+<h1><?= isset($customer['id']) ? 'Edit' : 'Add' ?> Customer</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($customer['name'] ?? '') ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Email</label>
+    <input type="email" name="email" class="form-control" value="<?= htmlspecialchars($customer['email'] ?? '') ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Phone</label>
+    <input type="text" name="phone" class="form-control" value="<?= htmlspecialchars($customer['phone'] ?? '') ?>">
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="index.php" class="btn btn-secondary">Cancel</a>
+</form>

--- a/src/templates/customers.php
+++ b/src/templates/customers.php
@@ -1,0 +1,20 @@
+<h1>Customers</h1>
+<table class="table table-striped">
+  <thead>
+    <tr><th>ID</th><th>Name</th><th>Email</th><th>Phone</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+  <?php foreach ($customers as $c): ?>
+    <tr>
+      <td><?= htmlspecialchars($c['id']) ?></td>
+      <td><?= htmlspecialchars($c['name']) ?></td>
+      <td><?= htmlspecialchars($c['email']) ?></td>
+      <td><?= htmlspecialchars($c['phone']) ?></td>
+      <td>
+        <a href="index.php?action=edit&id=<?= $c['id'] ?>" class="btn btn-sm btn-primary">Edit</a>
+        <a href="index.php?action=delete&id=<?= $c['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete?')">Delete</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>

--- a/src/templates/footer.php
+++ b/src/templates/footer.php
@@ -1,0 +1,3 @@
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/templates/header.php
+++ b/src/templates/header.php
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Simple CRM</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.php">CRM</a>
+    <div class="navbar-nav">
+      <a class="nav-link" href="index.php">Customers</a>
+      <a class="nav-link" href="index.php?action=create">Add Customer</a>
+    </div>
+  </div>
+</nav>

--- a/src/templates/layout.php
+++ b/src/templates/layout.php
@@ -1,0 +1,5 @@
+<?php include __DIR__ . '/header.php'; ?>
+<div class="container">
+<?php include __DIR__ . '/' . $template; ?>
+</div>
+<?php include __DIR__ . '/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add a barebones PHP CRM using SQLite
- provide simple templates for listing and editing customers
- document how to run the CRM

## Testing
- `php -l src/index.php`
- `php -l src/db.php`
- `php -l src/templates/layout.php src/templates/header.php src/templates/footer.php src/templates/customers.php src/templates/customer_form.php`
- `php -S localhost:8000 -t src` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_e_686cc9bdf6cc8327af37a18e2dfea522